### PR TITLE
For ck fixes

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsAMDGPU.td
+++ b/llvm/include/llvm/IR/IntrinsicsAMDGPU.td
@@ -1973,9 +1973,7 @@ class AMDGPURawBufferLoadLDS : Intrinsic <
                               //        gfx12+: bits [0-2] = th, bits [3-4] = scope,
                               //                bit 6 = swz
                               //           all: volatile op (bit 31, stripped at lowering)
-  [IntrWillReturn, IntrArgMemOnly,
-   WriteOnly<ArgIndex<1>>, NoCapture<ArgIndex<1>>, 
-   ImmArg<ArgIndex<2>>, ImmArg<ArgIndex<5>>,
+  [IntrWillReturn, NoCapture<ArgIndex<1>>, ImmArg<ArgIndex<2>>, ImmArg<ArgIndex<5>>,
    ImmArg<ArgIndex<6>>, IntrNoCallback, IntrNoFree], "", [SDNPMemOperand]>, AMDGPURsrcIntrinsic<0>;
 def int_amdgcn_raw_buffer_load_lds : AMDGPURawBufferLoadLDS;
 
@@ -2019,9 +2017,7 @@ class AMDGPUStructBufferLoadLDS : Intrinsic <
                               //        gfx12+: bits [0-2] = th, bits [3-4] = scope,
                               //                bit 6 = swz
                               //           all: volatile op (bit 31, stripped at lowering)
-  [IntrWillReturn, IntrArgMemOnly,
-   WriteOnly<ArgIndex<1>>, NoCapture<ArgIndex<1>>, 
-   ImmArg<ArgIndex<2>>, ImmArg<ArgIndex<6>>,
+  [IntrWillReturn, NoCapture<ArgIndex<1>>, ImmArg<ArgIndex<2>>, ImmArg<ArgIndex<6>>,
    ImmArg<ArgIndex<7>>, IntrNoCallback, IntrNoFree], "", [SDNPMemOperand]>, AMDGPURsrcIntrinsic<0>;
 def int_amdgcn_struct_buffer_load_lds : AMDGPUStructBufferLoadLDS;
 

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -1939,12 +1939,9 @@ bool SIInsertWaitcnts::generateWaitcntInstBefore(MachineInstr &MI,
         // LOAD_CNT is only relevant to vgpr or LDS.
         unsigned RegNo = FIRST_LDS_VGPR;
         // Only objects with alias scope info were added to LDSDMAScopes array.
-        // In the absense of the scope info we will not be able to disambiguate
-        // aliasing here. There is no need to try searching for a corresponding
-        // store slot. This is conservatively correct because in that case we
-        // will produce a wait using the first (general) LDS DMA wait slot which
-        // will wait on all of them anyway.
-        if (Ptr && Memop->getAAInfo() && Memop->getAAInfo().Scope) {
+        // AliasAnalysis query can determine aliasing even if Memop's Scope is
+        // missing.
+        if (Ptr && Memop->getAAInfo()) {
           const auto &LDSDMAStores = ScoreBrackets.getLDSDMAStores();
           for (unsigned I = 0, E = LDSDMAStores.size(); I != E; ++I) {
             if (MI.mayAlias(AA, *LDSDMAStores[I], true))


### PR DESCRIPTION
Contains 2 changes:
1) revert attribute changes to buffer.load.lds -- it was incorrect to allow read attributes on <4 x i32> rsrc parm, as llvm does not treat it like a ptr.
2) remove scope check in SIInsertWaitcnts.cpp and allow AA to determine aliasing between MIs. For ScopedNoAlias, LLVM allows for checking aliasing between MemLocs that is asymmetric, ie. one missing a !alias.scope, and still return NoAlias result. AMDGPU was being way more conservative by disallowing when scope was missing when ScopedNoAlias sufficiently handles asymmetry.